### PR TITLE
Remove data urls from network requests count

### DIFF
--- a/script/greenpanel.js
+++ b/script/greenpanel.js
@@ -213,7 +213,11 @@ function MeasuresAcquisition(rules) {
 
   getNetworkMeasure = () => {
     chrome.devtools.network.getHAR((har) => {
-      let entries = har.entries;
+      
+      debug(() => `Total resources (including data urls): ${har.entries.length}`);
+      // only account for network traffic, filtering resources embedded through data urls
+      let entries = har.entries.filter(entry => isNetworkResource(entry));
+      debug(() => `Network resources (excluding data urls): ${entries.length}`);
 
       // Get the "mother" url 
       if (entries.length > 0) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -241,6 +241,12 @@ function isMinified(scriptContent) {
 
 }
 
+/**
+ * Detect non-network resources (data urls embedded in page)
+ */
+function isNetworkResource(harEntry){
+  return !(harEntry.request.httpVersion === "data");
+}
 
 function computeNumberOfErrorsInJSCode(code, url) {
   let errorNumber =0;


### PR DESCRIPTION
Images embedded in HTML or CSS as data urls (https://developer.mozilla.org/fr/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) are currently counted as network requests.

This means pages using them have more network requests counted against them, and the payload is counted twice (once inside the HTML where it is embedded, and once when the request is accounted for in the har)

This patch filters data urls from the har results.